### PR TITLE
feat: 支持 coolmarket 搜索深链

### DIFF
--- a/app/src/main/java/com/example/c001apk/compose/constant/Constants.kt
+++ b/app/src/main/java/com/example/c001apk/compose/constant/Constants.kt
@@ -31,6 +31,7 @@ object Constants {
     const val PREFIX_DYH = "/dyh/"
     const val PREFIX_COLLECTION = "/collection/"
     const val PREFIX_EVENT = "/event/"
+    const val PREFIX_SEARCH = "/com.coolapk.market/search"
     const val SUFFIX_THUMBNAIL = ".s.jpg"
     const val SUFFIX_GIF = ".gif"
 

--- a/app/src/main/java/com/example/c001apk/compose/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/c001apk/compose/ui/main/MainActivity.kt
@@ -25,6 +25,7 @@ import androidx.core.view.WindowInsetsCompat
 import com.example.c001apk.compose.logic.providable.LocalUserPreferences
 import com.example.c001apk.compose.logic.repository.UserPreferencesRepository
 import com.example.c001apk.compose.ui.theme.C001apkComposeTheme
+import com.example.c001apk.compose.ui.search.SearchViewModel
 import com.example.c001apk.compose.util.CookieUtil.apiVersion
 import com.example.c001apk.compose.util.CookieUtil.customHaptics
 import com.example.c001apk.compose.util.CookieUtil.hapticFeedback
@@ -70,6 +71,7 @@ class MainActivity : ComponentActivity() {
     lateinit var userPreferencesRepository: UserPreferencesRepository
     private lateinit var navController: NavHostController
     private val viewModel by viewModels<MainViewModel>()
+    private val searchViewModel by viewModels<SearchViewModel>()
     private var stableStatusBarInset: Int? = null
 
     override fun onNewIntent(intent: Intent) {
@@ -83,7 +85,10 @@ class MainActivity : ComponentActivity() {
                 context = this,
                 url = it.toString(),
                 title = null,
-                needConvert = true
+                needConvert = true,
+                onSearch = { keyword ->
+                    searchViewModel.saveHistory(keyword)
+                }
             )
         }
     }

--- a/app/src/main/java/com/example/c001apk/compose/ui/main/MainNavigation.kt
+++ b/app/src/main/java/com/example/c001apk/compose/ui/main/MainNavigation.kt
@@ -47,6 +47,7 @@ import com.example.c001apk.compose.constant.Constants.PREFIX_FEED
 import com.example.c001apk.compose.constant.Constants.PREFIX_GAME
 import com.example.c001apk.compose.constant.Constants.PREFIX_HTTP
 import com.example.c001apk.compose.constant.Constants.PREFIX_PRODUCT
+import com.example.c001apk.compose.constant.Constants.PREFIX_SEARCH
 import com.example.c001apk.compose.constant.Constants.PREFIX_TOPIC
 import com.example.c001apk.compose.constant.Constants.PREFIX_USER
 import com.example.c001apk.compose.constant.Constants.PREFIX_USER_LIST
@@ -748,6 +749,7 @@ fun NavHostController.onOpenLink(
     url: String,
     title: String? = null,
     needConvert: Boolean = false,
+    onSearch: ((String) -> Unit)? = null,
     onViewFeed: ((String, Boolean) -> Unit)? = null,
 ) {
     if (url.isEmpty())
@@ -834,6 +836,16 @@ fun NavHostController.onOpenLink(
                 .substringBefore('?')
                 .substringBefore('/')
             if (id.isNotEmpty()) navigateToEvent(id)
+        }
+
+        path.startsWith(PREFIX_SEARCH) -> {
+            val keyword = Uri.parse(path).getQueryParameter("searchValue").orEmpty()
+            if (keyword.isEmpty()) {
+                navigateToSearch(null, null, null)
+            } else {
+                onSearch?.invoke(keyword)
+                navigateToSearchResult(keyword, null, null, null)
+            }
         }
 
         else -> {

--- a/app/src/main/java/com/example/c001apk/compose/ui/main/MainNavigation.kt
+++ b/app/src/main/java/com/example/c001apk/compose/ui/main/MainNavigation.kt
@@ -839,7 +839,10 @@ fun NavHostController.onOpenLink(
         }
 
         path.startsWith(PREFIX_SEARCH) -> {
-            val keyword = Uri.parse(path).getQueryParameter("searchValue").orEmpty()
+            val sourceUri = Uri.parse(url)
+                .takeIf { it.scheme.equals(PREFIX_COOLMARKET.removeSuffix("://"), ignoreCase = true) }
+                ?: Uri.parse(path)
+            val keyword = sourceUri.getQueryParameter("searchValue").orEmpty()
             if (keyword.isEmpty()) {
                 navigateToSearch(null, null, null)
             } else {


### PR DESCRIPTION
支持通过 coolmarket 链接直接唤起搜索：

- 不带参数：打开搜索页
- 带 searchValue：直接搜索并进入结果页，关键词写入搜索历史

示例：coolmarket://com.coolapk.market/search?searchValue=微信

改动文件：Constants.kt、MainNavigation.kt、MainActivity.kt，Manifest 无需修改。

测试：adb shell am start -a android.intent.action.VIEW -d "coolmarket://com.coolapk.market/search?searchValue=%E5%BE%AE%E4%BF%A1"